### PR TITLE
Add TeamSpeak Server support fixes #42

### DIFF
--- a/src/main/java/com/gameservermanagers/JavaGSM/JavaGSM.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/JavaGSM.java
@@ -333,13 +333,13 @@ public class JavaGSM {
     // region Header
     private static void header() {
         // Looks weird due to escape characters, run to see actual ascii "Art"
-        System.out.println ("       _                   _____  _____ __  __ ");
-        System.out.println ("      | |                 / ____|/ ____|  \\/  |");
-        System.out.println ("      | | __ ___   ____ _| |  __| (___ | \\  / |");
-        System.out.println ("  _   | |/ _` \\ \\ / / _` | | |_ |\\___ \\| |\\/| |");
-        System.out.println (" | |__| | (_| |\\ V / (_| | |__| |____) | |  | |");
-        System.out.println ("  \\____/ \\__,_| \\_/ \\__,_|\\_____|_____/|_|  |_|");
-        System.out.println ("                                               ");
+        System.out.println("       _                   _____  _____ __  __ ");
+        System.out.println("      | |                 / ____|/ ____|  \\/  |");
+        System.out.println("      | | __ ___   ____ _| |  __| (___ | \\  / |");
+        System.out.println("  _   | |/ _` \\ \\ / / _` | | |_ |\\___ \\| |\\/| |");
+        System.out.println(" | |__| | (_| |\\ V / (_| | |__| |____) | |  | |");
+        System.out.println("  \\____/ \\__,_| \\_/ \\__,_|\\_____|_____/|_|  |_|");
+        System.out.println("                                               ");
     }
     //endregion
     //endregion

--- a/src/main/java/com/gameservermanagers/JavaGSM/servers/TeamSpeak3.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/servers/TeamSpeak3.java
@@ -1,0 +1,100 @@
+package com.gameservermanagers.JavaGSM.servers;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.gameservermanagers.JavaGSM.ServerInstaller;
+import com.gameservermanagers.JavaGSM.util.DownloadUtil;
+import com.gameservermanagers.JavaGSM.util.UserInputUtil;
+
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class TeamSpeak3 extends ServerInstaller {
+	
+	  private static String getSoftware(String prompt, String filter) {
+	        // populate possible server software
+	        List<String> availableServerSoftware = new LinkedList<>();
+	        for (Method method : TeamSpeak3.class.getDeclaredMethods())
+	            if (method.getName().startsWith(filter)) availableServerSoftware.add(method.getName().substring(8));
+	        Collections.sort(availableServerSoftware);
+
+	        return availableServerSoftware.get(UserInputUtil.questionList(prompt, availableServerSoftware));
+	    }
+	
+	 public static void install(File destination) {
+		 String requestedSoftware = getSoftware("Which server software do you want to install", "install_");
+		 System.out.println("Installing " + requestedSoftware + "...\n");
+		 
+	        String ts3File = null;
+	        for(Method method : TeamSpeak3.class.getDeclaredMethods()) 
+	        	if(method.getName().equals("install_" + requestedSoftware)) try {
+	        			ts3File = String.valueOf(method.invoke(null, destination));
+	        			System.out.println();
+	        		} catch(Exception e) {
+	        			e.printStackTrace();
+	       }
+	        
+	        if(ts3File == null) {
+	           System.out.println("Installation failed.");
+	           return;
+	        }
+	        
+	 }
+	 
+	 // Installs 32-bit version of TeamSpeak 3 Server
+	 public static void install_TS3Windows32(File destination) {
+		 String zipFile = "teamspeak3-server_win32-3.0.13.6.zip";
+		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
+		 DownloadUtil.download(downloadURL);
+		 DownloadUtil.unzip(new File(zipFile), destination);
+		 DownloadUtil.deleteFile(new File(zipFile));
+		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_win32"), true);
+		 System.out.println();
+		 
+	 }
+	 
+	 // Installs 64-bit version of TeamSpeak 3 Server
+	 public static void install_TS3Windows64(File destination) {
+		 String zipFile = "teamspeak3-server_win64-3.0.13.6.zip";
+		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
+		 DownloadUtil.download(downloadURL);
+		 DownloadUtil.unzip(new File(zipFile), destination);
+		 DownloadUtil.deleteFile(new File(zipFile));
+		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_win64"), true);
+		 System.out.println();
+	 }
+ 
+	 public static void install_TS3Linux32(File destination) {
+		 String tarFile = "teamspeak3-server_linux_x86-3.0.13.6.tar.bz2";
+		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + tarFile;
+		 DownloadUtil.download(downloadURL);
+		 DownloadUtil.unbzip(new File(tarFile), destination);
+		 DownloadUtil.deleteFile(new File(tarFile));
+		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_x86"), true);
+	 }
+	 
+	 public static void install_TS3Linux64(File destination) {
+		 String tarFile = "teamspeak3-server_linux_amd64-3.0.13.6.tar.bz2";
+		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + tarFile;
+		 DownloadUtil.download(downloadURL);
+		 DownloadUtil.unbzip(new File(tarFile), destination);
+		 DownloadUtil.deleteFile(new File(tarFile));
+		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_amd64"), true);
+	 }
+	 
+	 // Teamspeak Server for Mac only supports 64-bit Mac OS systems.
+	 public static void install_TS3Mac(File destination) {
+		 String zipFile = "teamspeak3-server_mac-3.0.13.6.zip";
+		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
+		 DownloadUtil.download(downloadURL, new File(destination, zipFile));
+		 DownloadUtil.unzip(new File(zipFile), destination);
+		 DownloadUtil.deleteFile(new File(zipFile));
+		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "dist"), true);
+		 System.out.println();
+	 }
+}

--- a/src/main/java/com/gameservermanagers/JavaGSM/servers/TeamSpeak3.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/servers/TeamSpeak3.java
@@ -6,9 +6,13 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.gameservermanagers.JavaGSM.JavaGSM;
 import com.gameservermanagers.JavaGSM.ServerInstaller;
+import com.gameservermanagers.JavaGSM.util.ConfigUtil;
 import com.gameservermanagers.JavaGSM.util.DownloadUtil;
+import com.gameservermanagers.JavaGSM.util.RuntimeUtil;
 import com.gameservermanagers.JavaGSM.util.UserInputUtil;
+import com.google.gson.internal.LinkedTreeMap;
 
 import net.lingala.zip4j.core.ZipFile;
 import net.lingala.zip4j.exception.ZipException;
@@ -44,6 +48,9 @@ public class TeamSpeak3 extends ServerInstaller {
 	           return;
 	        }
 	        
+	     File ts3Config = new File(destination, "gsm.json");
+	     ConfigUtil.writeDefaultConfigToFile(TeamSpeak3.class, ts3Config);
+	     
 	 }
 	 
 	 // Installs 32-bit version of TeamSpeak 3 Server
@@ -87,14 +94,12 @@ public class TeamSpeak3 extends ServerInstaller {
 		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_amd64"), true);
 	 }
 	 
-	 // Teamspeak Server for Mac only supports 64-bit Mac OS systems.
-	 public static void install_TS3Mac(File destination) {
-		 String zipFile = "teamspeak3-server_mac-3.0.13.6.zip";
-		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
-		 DownloadUtil.download(downloadURL, new File(destination, zipFile));
-		 DownloadUtil.unzip(new File(zipFile), destination);
-		 DownloadUtil.deleteFile(new File(zipFile));
-		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "dist"), true);
-		 System.out.println();
+	 public static void start(File target) {
+		 LinkedTreeMap<String, Object> config = ConfigUtil.getConfigFromFile(new File(target, "gsm.json"));
+		 if(JavaGSM.isWindows) {
+			 RuntimeUtil.runProcess("cmd /C ts3server", target, false);
+		 } else if(JavaGSM.isLinux) {
+			 RuntimeUtil.runProcess("./ts3server_startscript.sh start", target, false);
+		 }
 	 }
 }

--- a/src/main/java/com/gameservermanagers/JavaGSM/servers/TeamSpeak3.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/servers/TeamSpeak3.java
@@ -1,11 +1,5 @@
 package com.gameservermanagers.JavaGSM.servers;
 
-import java.io.File;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
 import com.gameservermanagers.JavaGSM.JavaGSM;
 import com.gameservermanagers.JavaGSM.ServerInstaller;
 import com.gameservermanagers.JavaGSM.util.ConfigUtil;
@@ -14,92 +8,94 @@ import com.gameservermanagers.JavaGSM.util.RuntimeUtil;
 import com.gameservermanagers.JavaGSM.util.UserInputUtil;
 import com.google.gson.internal.LinkedTreeMap;
 
-import net.lingala.zip4j.core.ZipFile;
-import net.lingala.zip4j.exception.ZipException;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class TeamSpeak3 extends ServerInstaller {
-	
-	  private static String getSoftware(String prompt, String filter) {
-	        // populate possible server software
-	        List<String> availableServerSoftware = new LinkedList<>();
-	        for (Method method : TeamSpeak3.class.getDeclaredMethods())
-	            if (method.getName().startsWith(filter)) availableServerSoftware.add(method.getName().substring(8));
-	        Collections.sort(availableServerSoftware);
 
-	        return availableServerSoftware.get(UserInputUtil.questionList(prompt, availableServerSoftware));
-	    }
-	
-	 public static void install(File destination) {
-		 String requestedSoftware = getSoftware("Which server software do you want to install", "install_");
-		 System.out.println("Installing " + requestedSoftware + "...\n");
-		 
-	        String ts3File = null;
-	        for(Method method : TeamSpeak3.class.getDeclaredMethods()) 
-	        	if(method.getName().equals("install_" + requestedSoftware)) try {
-	        			ts3File = String.valueOf(method.invoke(null, destination));
-	        			System.out.println();
-	        		} catch(Exception e) {
-	        			e.printStackTrace();
-	       }
-	        
-	        if(ts3File == null) {
-	           System.out.println("Installation failed.");
-	           return;
-	        }
-	        
-	     File ts3Config = new File(destination, "gsm.json");
-	     ConfigUtil.writeDefaultConfigToFile(TeamSpeak3.class, ts3Config);
-	     
-	 }
-	 
-	 // Installs 32-bit version of TeamSpeak 3 Server
-	 public static void install_TS3Windows32(File destination) {
-		 String zipFile = "teamspeak3-server_win32-3.0.13.6.zip";
-		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
-		 DownloadUtil.download(downloadURL);
-		 DownloadUtil.unzip(new File(zipFile), destination);
-		 DownloadUtil.deleteFile(new File(zipFile));
-		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_win32"), true);
-		 System.out.println();
-		 
-	 }
-	 
-	 // Installs 64-bit version of TeamSpeak 3 Server
-	 public static void install_TS3Windows64(File destination) {
-		 String zipFile = "teamspeak3-server_win64-3.0.13.6.zip";
-		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
-		 DownloadUtil.download(downloadURL);
-		 DownloadUtil.unzip(new File(zipFile), destination);
-		 DownloadUtil.deleteFile(new File(zipFile));
-		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_win64"), true);
-		 System.out.println();
-	 }
- 
-	 public static void install_TS3Linux32(File destination) {
-		 String tarFile = "teamspeak3-server_linux_x86-3.0.13.6.tar.bz2";
-		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + tarFile;
-		 DownloadUtil.download(downloadURL);
-		 DownloadUtil.unbzip(new File(tarFile), destination);
-		 DownloadUtil.deleteFile(new File(tarFile));
-		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_x86"), true);
-	 }
-	 
-	 public static void install_TS3Linux64(File destination) {
-		 String tarFile = "teamspeak3-server_linux_amd64-3.0.13.6.tar.bz2";
-		 String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + tarFile;
-		 DownloadUtil.download(downloadURL);
-		 DownloadUtil.unbzip(new File(tarFile), destination);
-		 DownloadUtil.deleteFile(new File(tarFile));
-		 DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_amd64"), true);
-	 }
-	 
-	 public static void start(File target) {
-		 LinkedTreeMap<String, Object> config = ConfigUtil.getConfigFromFile(new File(target, "gsm.json"));
-		 if(JavaGSM.isWindows) {
-			 RuntimeUtil.runProcess("cmd /C ts3server", target, false);
-		 } else if(JavaGSM.isLinux) {
-			 RuntimeUtil.runProcess("./ts3server_startscript.sh start", target, false);
-		 }
-	 }
+    private static String getSoftware(String prompt, String filter) {
+        // populate possible server software
+        List<String> availableServerSoftware = new LinkedList<>();
+        for (Method method : TeamSpeak3.class.getDeclaredMethods())
+            if (method.getName().startsWith(filter)) availableServerSoftware.add(method.getName().substring(8));
+        Collections.sort(availableServerSoftware);
+
+        return availableServerSoftware.get(UserInputUtil.questionList(prompt, availableServerSoftware));
+    }
+
+    public static void install(File destination) {
+        String requestedSoftware = getSoftware("Which server software do you want to install", "install_");
+        System.out.println("Installing " + requestedSoftware + "...\n");
+
+        String ts3File = null;
+        for (Method method : TeamSpeak3.class.getDeclaredMethods())
+            if (method.getName().equals("install_" + requestedSoftware)) try {
+                ts3File = String.valueOf(method.invoke(null, destination));
+                System.out.println();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+        if (ts3File == null) {
+            System.out.println("Installation failed.");
+            return;
+        }
+
+        File ts3Config = new File(destination, "gsm.json");
+        ConfigUtil.writeDefaultConfigToFile(TeamSpeak3.class, ts3Config);
+    }
+
+    // Installs 32-bit version of TeamSpeak 3 Server
+    public static void install_TS3Windows32(File destination) {
+        String zipFile = "teamspeak3-server_win32-3.0.13.6.zip";
+        String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
+        DownloadUtil.download(downloadURL);
+        DownloadUtil.unzip(new File(zipFile), destination);
+        DownloadUtil.deleteFile(new File(zipFile));
+        DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_win32"), true);
+        System.out.println();
+    }
+
+    // Installs 64-bit version of TeamSpeak 3 Server
+    public static void install_TS3Windows64(File destination) {
+        String zipFile = "teamspeak3-server_win64-3.0.13.6.zip";
+        String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + zipFile;
+        DownloadUtil.download(downloadURL);
+        DownloadUtil.unzip(new File(zipFile), destination);
+        DownloadUtil.deleteFile(new File(zipFile));
+        DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_win64"), true);
+        System.out.println();
+    }
+
+    public static void install_TS3Linux32(File destination) {
+        String tarFile = "teamspeak3-server_linux_x86-3.0.13.6.tar.bz2";
+        String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + tarFile;
+        DownloadUtil.download(downloadURL);
+        DownloadUtil.unbzip(new File(tarFile), destination);
+        DownloadUtil.deleteFile(new File(tarFile));
+        DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_x86"), true);
+    }
+
+    public static void install_TS3Linux64(File destination) {
+        String tarFile = "teamspeak3-server_linux_amd64-3.0.13.6.tar.bz2";
+        String downloadURL = "http://dl.4players.de/ts/releases/3.0.13.6/" + tarFile;
+        DownloadUtil.download(downloadURL);
+        DownloadUtil.unbzip(new File(tarFile), destination);
+        DownloadUtil.deleteFile(new File(tarFile));
+        DownloadUtil.moveAllChildrenOfFolderToParent(new File(destination, "teamspeak3-server_linux_amd64"), true);
+    }
+
+    public static void start(File target) {
+        LinkedTreeMap<String, Object> config = ConfigUtil.getConfigFromFile(new File(target, "gsm.json"));
+        if (JavaGSM.isWindows) {
+            RuntimeUtil.runProcess("cmd /C ts3server", target, false);
+        } else if (JavaGSM.isLinux) {
+            RuntimeUtil.runProcess("./ts3server_startscript.sh start", target, false);
+        }
+    }
+
 }

--- a/src/main/java/com/gameservermanagers/JavaGSM/util/DownloadUtil.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/util/DownloadUtil.java
@@ -7,7 +7,9 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.jsoup.Jsoup;
+import org.rauschig.jarchivelib.ArchiveFormat;
 import org.rauschig.jarchivelib.ArchiverFactory;
+import org.rauschig.jarchivelib.CompressionType;
 
 import java.io.File;
 import java.io.IOException;
@@ -118,4 +120,15 @@ public class DownloadUtil {
         System.out.println(" done in " + (System.currentTimeMillis() - startTime) + "ms");
     }
 
+    public static void unbzip(File source) {
+    	unbzip(source, source.getParentFile());
+    }
+    
+    public static void unbzip(File source, File destination) {
+         try {
+             ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.BZIP2).extract(source, destination);
+         } catch (IOException e) {
+             e.printStackTrace();
+         }
+    }
 }

--- a/src/main/java/com/gameservermanagers/JavaGSM/util/DownloadUtil.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/util/DownloadUtil.java
@@ -112,7 +112,7 @@ public class DownloadUtil {
         System.out.print("Ungzipping " + source.getName() + " to " + destination.getPath() + "...");
 
         try {
-            ArchiverFactory.createArchiver("tar", "gz").extract(source, destination);
+            ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.GZIP).extract(source, destination);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -123,12 +123,17 @@ public class DownloadUtil {
     public static void unbzip(File source) {
     	unbzip(source, source.getParentFile());
     }
-    
     public static void unbzip(File source, File destination) {
-         try {
-             ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.BZIP2).extract(source, destination);
-         } catch (IOException e) {
-             e.printStackTrace();
-         }
+        long startTime = System.currentTimeMillis();
+        System.out.print("Unbzipping " + source.getName() + " to " + destination.getPath() + "...");
+
+        try {
+            ArchiverFactory.createArchiver(ArchiveFormat.TAR, CompressionType.BZIP2).extract(source, destination);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println(" done in " + (System.currentTimeMillis() - startTime) + "ms");
     }
+
 }

--- a/src/main/java/com/gameservermanagers/JavaGSM/util/RuntimeUtil.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/util/RuntimeUtil.java
@@ -14,7 +14,7 @@ public class RuntimeUtil {
     }
     public static Process runProcess(String command, File directory, boolean gobble) {
             try {
-            System.out.println("Running command \"" + command + "\" in " + directory.getAbsolutePath());
+            System.out.println("Running command \"" + command + "\"");
             Process p = Runtime.getRuntime().exec(command, null, directory);
 
             if (p != null && gobble) {

--- a/src/main/java/com/gameservermanagers/JavaGSM/util/RuntimeUtil.java
+++ b/src/main/java/com/gameservermanagers/JavaGSM/util/RuntimeUtil.java
@@ -14,7 +14,7 @@ public class RuntimeUtil {
     }
     public static Process runProcess(String command, File directory, boolean gobble) {
             try {
-            System.out.println("Running command \"" + command + "\"");
+            System.out.println("Running command \"" + command + "\" in " + directory.getAbsolutePath());
             Process p = Runtime.getRuntime().exec(command, null, directory);
 
             if (p != null && gobble) {


### PR DESCRIPTION
Adds support for TeamSpeak 3 servers.

The testing was done on Windows 10 Pro & CentOS 7 Minimal via HyperV.

If you have any questions, feel free to ask.